### PR TITLE
Clean up packaging, include license.

### DIFF
--- a/lib/quantile/version.rb
+++ b/lib/quantile/version.rb
@@ -12,5 +12,5 @@
 # limitations under the License.
 
 module Quantile
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/quantile.gemspec
+++ b/quantile.gemspec
@@ -4,16 +4,14 @@ Gem::Specification.new do |gem|
   gem.name    = 'quantile'
   gem.version = Quantile::VERSION
   gem.date    = '2013-07-22'
+  gem.license = ['Apache 2.0']
 
-  gem.summary = "Streaming Quantile Estimation"
+  gem.summary = 'Streaming Quantile Estimation'
   gem.description = "Graham Cormode and S. Muthukrishnan's Effective Computation of Biased Quantiles over Data Streams in ICDE’05"
 
   gem.authors  = ['Matt T. Proud']
   gem.email    = 'matt.proud@gmail.com'
   gem.homepage = 'http://github.com/matttproud/ruby_quantile_estimation'
-
-  gem.add_dependency('rake')
-  gem.add_development_dependency('rspec', [">= 2.0.0"])
 
   gem.files = Dir['lib/quantile.rb', 'lib/quantile/quantile.rb', 'lib/quantile/estimator.rb', 'lib/quantile/version.rb', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")
 end


### PR DESCRIPTION
Quantile is Apache 2.0-licensed.  This should be noted.

All tests have been implemented via blackbox verifications, so the
boilerplate dependencies should be removed until tests are added.
