### PR TITLE
Fix observations counting

### DIFF
--- a/lib/quantile/estimator.rb
+++ b/lib/quantile/estimator.rb
@@ -66,6 +66,7 @@ module Quantile
       if @buffer.size == BUFFER_SIZE
         flush
       end
+      @observations += 1
     end
 
     #
@@ -138,8 +139,6 @@ module Quantile
     end
 
     def record(value, rank, delta, successor)
-      @observations += 1
-
       return Sample.new(value, rank, delta, successor)
     end
 

--- a/spec/estimator_spec.rb
+++ b/spec/estimator_spec.rb
@@ -32,14 +32,24 @@ describe Quantile::Estimator do
     end
   end
 
+  describe '#observations' do
+    it 'returns the numer of recorded observations' do
+      expect do
+        42.times { estimator.observe(rand) }
+      end.to change { estimator.observations }.from(0).to(42)
+    end
+  end
+
   describe '#query' do
     it 'returns the current quantile value for a given rank' do
       estimator.observe(0.8)
       estimator.observe(0.4)
+      estimator.observe(0.9)
       estimator.observe(0.6)
 
       estimator.query(0.5).should == 0.6
       estimator.query(0.9).should == 0.8
+      estimator.query(0.99).should == 0.8
     end
 
     it 'returns nil if no observations are available' do


### PR DESCRIPTION
My gut feeling told me the observations counting is not correct, so I added an test and it turned out to be true:

```
Failures:

  1) Quantile::Estimator#observations returns the numer of recorded observations
     Failure/Error: estimator.observations.should == 42
       expected: 42
            got: 83 (using ==)
     # ./spec/estimator_spec.rb:39:in `block (3 levels) in <top (required)>'
```

While the easy fix would be to move the `@oberservations` increment our of the `#record` method, ideally we wouldn't need to create all these `Sample` values for performance reasons.
