### PR TITLE
Fix bug in quantile estimations resulting in inaccurate results

### DIFF
--- a/lib/quantile/estimator.rb
+++ b/lib/quantile/estimator.rb
@@ -138,11 +138,12 @@ module Quantile
           current = current.successor
         end
 
-        unless current.successor
+        if current.successor
+          current.successor = record(s, 1, invariant(rank, @observations)-1, current.successor)
+        else
           current.successor = record(s, 1, 0, nil)
         end
-
-        current.successor = record(s, 1, invariant(rank, @observations)-1, current.successor)
+        current = current.successor
       end
     end
 


### PR DESCRIPTION
The current implementation double counts many inputs, resulting in completely inaccurate results.

Below I've added a quick couple tests I did to verify the changes. You can see clearly the old implementation was completely wrong, yet the new one is within the expected margin of error. Here's the before and after:

```
numbers from 1 -> 1,000,000
OLD:
50th: 251919
90th: 449900
99th: 495284

NEW:
50th: 523945
90th: 904776
99th: 990792



numbers from 1 -> 100,000 + 50,000 -> 100,000
OLD:
50th: 39616
90th: 62061
99th: 66176

NEW:
50th: 65194
90th: 92842
99th: 99190
```

Bug found in https://github.com/prometheus/client_ruby/issues/76